### PR TITLE
Add support for return status value of 9

### DIFF
--- a/device.go
+++ b/device.go
@@ -554,7 +554,7 @@ func waitAsyncStatus(v *Session, refreshID string, ch chan error,
 		}
 
 		// End when status == 4 || status == 9
-    // Setting DateTime returns status 9 on success
+		// Setting DateTime returns status 9 on success
 		if status >= 4 {
 			if status != 4 && status != 9 {
 				ch <- fmt.Errorf("Unexpected status %d", status)

--- a/device.go
+++ b/device.go
@@ -553,9 +553,10 @@ func waitAsyncStatus(v *Session, refreshID string, ch chan error,
 			break
 		}
 
-		// End when status == 4
+		// End when status == 4 || status == 9
+    // Setting DateTime returns status 9 on success
 		if status >= 4 {
-			if status != 4 {
+			if status != 4 && status != 9 {
 				ch <- fmt.Errorf("Unexpected status %d", status)
 			}
 			break


### PR DESCRIPTION
This fixes the error returned when setting DateTime. See #9 for reference.