### PR TITLE
Use HTTPS instead of HTTP when connect to Viessmann

### DIFF
--- a/vitotrol.go
+++ b/vitotrol.go
@@ -11,7 +11,7 @@ import (
 )
 
 // MainURL is the Viessmann Vitodata API URL.
-var MainURL = `http://www.viessmann.com/app_vitodata/VIIWebService-1.16.0.0/iPhoneWebService.asmx`
+var MainURL = `https://www.viessmann.com/app_vitodata/VIIWebService-1.16.0.0/iPhoneWebService.asmx`
 
 const (
 	soapURL = `http://www.e-controlnet.de/services/vii/`


### PR DESCRIPTION
Viessmann doesn't redirect to HTTPS so using HTTP login credentials sent
in clear text. HTTPS is supported by the server and seems to work fine
for a couple days for me. You can check that clear text is used with:

sudo tcpdump host www.viessmann.com -A